### PR TITLE
Feature externalsources

### DIFF
--- a/DSCResources/xMaintenanceWindow/xMaintenanceWindow.psm1
+++ b/DSCResources/xMaintenanceWindow/xMaintenanceWindow.psm1
@@ -48,6 +48,10 @@ function Get-DayOfMonth
     The day the maintenance window is defined for. ScheduleEnd can exceed the DayOfWeek
 .PARAMETER DayOfMonth
     The nth day of a month. In conjunction with DayOfWeek uses e.g. the nth Monday of the month
+.PARAMETER ScriptBlock
+    The script block to generate a schedule from an external system, e.g. a CMDB, a file, the moon phase, ... Needs to return a hash table with the keys
+    ScheduleStart and ScheduleEnd. Can optionally contain all parameters of the DSC resource except ScriptBlock to further control resource processing.
+    If ScriptBlock is used, all parameters are ignored.
 #>
 function Get-TargetResource
 {
@@ -72,13 +76,16 @@ function Get-TargetResource
         $DayOfWeek,
 
         [System.Int16]
-        $DayOfMonth
+        $DayOfMonth,
+
+        [System.String]
+        $ScriptBlock
     )
 
     $returnValue = @{
         ScheduleStart = $ScheduleStart
-        ScheduleEnd = $ScheduleEnd
-        CurrentTime = Get-Date
+        ScheduleEnd   = $ScheduleEnd
+        CurrentTime   = Get-Date
     }
 
     return $returnValue
@@ -98,6 +105,10 @@ function Get-TargetResource
     The day the maintenance window is defined for. ScheduleEnd can exceed the DayOfWeek
 .PARAMETER DayOfMonth
     The nth day of a month. In conjunction with DayOfWeek uses e.g. the nth Monday of the month
+.PARAMETER ScriptBlock
+    The script block to generate a schedule from an external system, e.g. a CMDB, a file, the moon phase, ... Needs to return a hash table with the keys
+    ScheduleStart and ScheduleEnd. Can optionally contain all parameters of the DSC resource except ScriptBlock to further control resource processing.
+    If ScriptBlock is used, all parameters are ignored.
 #>
 function Set-TargetResource
 {
@@ -121,7 +132,10 @@ function Set-TargetResource
         $DayOfWeek,
 
         [System.Int16]
-        $DayOfMonth
+        $DayOfMonth,
+
+        [System.String]
+        $ScriptBlock
     )
 
     # Set should throw when in window to cancel processing
@@ -146,6 +160,10 @@ function Set-TargetResource
     The day the maintenance window is defined for. ScheduleEnd can exceed the DayOfWeek
 .PARAMETER DayOfMonth
     The nth day of a month. In conjunction with DayOfWeek uses e.g. the nth Monday of the month
+.PARAMETER ScriptBlock
+    The script block to generate a schedule from an external system, e.g. a CMDB, a file, the moon phase, ... Needs to return a hash table with the keys
+    ScheduleStart and ScheduleEnd. Can optionally contain all parameters of the DSC resource except ScriptBlock to further control resource processing.
+    If ScriptBlock is used, all parameters are ignored.
 #>
 function Test-TargetResource
 {
@@ -170,7 +188,10 @@ function Test-TargetResource
         $DayOfWeek,
 
         [System.Int16]
-        $DayOfMonth
+        $DayOfMonth,
+
+        [System.String]
+        $ScriptBlock
     )
 
     $currentValues = Get-TargetResource @PSBoundParameters
@@ -179,6 +200,52 @@ function Test-TargetResource
     $shouldSkipSet = $true
 
     Write-Verbose -Message ('Start: {0}, End {1}, Current: {2}' -f $ScheduleStart.TimeOfDay, $ScheduleEnd.TimeOfDay, $now)
+
+    if (-not [System.String]::IsNullOrWhiteSpace($ScriptBlock))
+    {
+        try
+        {
+            $executableScriptBlock = [scriptblock]::Create($ScriptBlock)
+            $externalValues = $executableScriptBlock.Invoke()
+
+            if ($externalValues.Count -gt 1)
+            {
+                throw 'More than one object has been returned from the external script block.'
+            }
+
+            if (-not ($externalValues[0].ContainsKey('ScheduleStart') -and $externalValues[0].ContainsKey('ScheduleEnd')))
+            {
+                throw 'Mandatory keys ScheduleStart and ScheduleEnd are missing'
+            }
+
+            $ScheduleStart = $externalValues[0].ScheduleStart
+            $ScheduleEnd = $externalValues[0].ScheduleEnd
+
+            if ($externalValues[0].ContainsKey('ScheduleType'))
+            {
+                $ScheduleType = $externalValues[0].ScheduleType
+            }
+            
+            if ($externalValues[0].ContainsKey('DayOfWeek'))
+            {
+                $DayOfWeek = $externalValues[0].DayOfWeek
+            }
+
+            if ($externalValues[0].ContainsKey('DayOfMonth'))
+            {
+                $DayOfMonth = $externalValues[0].DayOfMonth
+            }
+
+            $Message = "External script returned the following key-value-pairs:`r`n{0}" -f (($externalValues[0].GetEnumerator() | ForEach-Object {"$($_.Key): $($_.Value)"} ) -join "`r`n") 
+            Write-Verbose -Message $Message -Verbose
+        }
+        catch
+        {
+            Write-Error -Message 'Could not create/execute script block from parameter value.' `
+                -TargetObject $ScriptBlock `
+                -RecommendedAction 'Load the script block into an editor of your choice and look for syntax errors.'
+        }
+    }
 
     if ($ScheduleStart.TimeOfDay -le $ScheduleEnd.TimeOfDay)
     {

--- a/DSCResources/xMaintenanceWindow/xMaintenanceWindow.psm1
+++ b/DSCResources/xMaintenanceWindow/xMaintenanceWindow.psm1
@@ -237,7 +237,7 @@ function Test-TargetResource
             }
 
             $Message = "External script returned the following key-value-pairs:`r`n{0}" -f (($externalValues[0].GetEnumerator() | ForEach-Object {"$($_.Key): $($_.Value)"} ) -join "`r`n") 
-            Write-Verbose -Message $Message -Verbose
+            Write-Verbose -Message $Message
         }
         catch
         {

--- a/DSCResources/xMaintenanceWindow/xMaintenanceWindow.schema.mof
+++ b/DSCResources/xMaintenanceWindow/xMaintenanceWindow.schema.mof
@@ -8,5 +8,6 @@ class xMaintenanceWindow : OMI_BaseResource
     [Write, Description("The desired schedule. If the default Once is used, the exact date will be checked. If Daily is specified, DayOfWeek, DayOfMonth and DayNameOfMonth are ignored. If Weekly is specified, DayOfMonth is ignored. If Monthly is specified, DayOfWeek can be used to express nth Monday of the month"), ValueMap{"Once", "Daily","Weekly","Monthly"}, Values{"Once", "Daily","Weekly","Monthly"}] String ScheduleType[];
     [Write, Description("The day the maintenance window is defined for. ScheduleEnd can exceed the DayOfWeek") , ValueMap{"Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"}, Values{"Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"}] String DayOfWeek;
     [Write, Description("The nth day of a month. In conjunction with DayOfWeek uses e.g. the nth Monday of the month")] Sint16 DayOfMonth;
+    [Write, Description("The script block to generate a schedule from an external system, e.g. a CMDB, a file, the moon phase, ... Needs to return a hash table with the keys ScheduleStart and ScheduleEnd. Can optionally contain all parameters of the DSC resource except ScriptBlock to further control resource processing. If ScriptBlock is used, all parameters are ignored.")] String ScriptBlock;
 };
 

--- a/Tests/Unit/xMaintenanceWindow.Tests.ps1
+++ b/Tests/Unit/xMaintenanceWindow.Tests.ps1
@@ -185,6 +185,38 @@ try
 
             Assert-VerifiableMocks
         }
+
+        Describe "$($script:DSCResourceName) - ScriptBlock" {
+            $testParameters = @{
+                ScheduleStart = (Get-Date).AddHours(-1)
+                ScheduleEnd = (Get-Date).AddHours(1)
+                ScriptBlock = "@{
+                    ScheduleStart = [datetime]::Now.AddHours(-1)
+                    ScheduleEnd = [datetime]::Now.AddHours(1)
+                    ScheduleType = 'Daily'
+                }"
+            }
+
+            Context 'The current time does not fall within the maintenance window' {
+                Mock -CommandName Get-Date -MockWith { [System.DateTime] '0001-01-01 07:00:00'  }
+                It "Should test false" {
+                    Test-TargetResource @testParameters | Should Be $false
+                }
+            }
+
+            Context 'The current time falls within the maintenance window' {
+
+                It "Should return true in Test-TargetResource" {
+                    Test-TargetResource @testParameters | Should Be $true
+                }
+
+                It "Should throw in Set-TargetResource" {
+                    {Set-TargetResource @testParameters} | Should Throw
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
     }
 }
 finally

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ install:
         Pop-Location
         Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
         Install-Module -Name Pester -Repository PSGallery -Force
+environment:
+  apikey:
+    secure: OX4AxdrgR7cWD+b3x/ZcjN87ij7UM1+HYsd/L3CJKxAkJ2ZEX3lIgvWDuoTMcKNM
 #---------------------------------#
 #      build configuration        #
 #---------------------------------#
@@ -44,6 +47,12 @@ deploy_script:
       $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
       Add-Type -assemblyname System.IO.Compression.FileSystem
       [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
+
+      # Deploy!
+      if ( $env:APPVEYOR_REPO_BRANCH -eq 'master' )
+      {
+        Publish-Module -Path $pwd -NuGetApiKey $env:apikey -Verbose
+      }
 
       # Creating NuGet package artifact
       New-Nuspec -packageName $env:APPVEYOR_PROJECT_NAME -version "$($env:APPVEYOR_BUILD_VERSION)" -author "Jan-Hendrik Peters" -owners "Jan-Hendrik Peters" -licenseUrl "https://github.com/nyanhp/xDscHelper/blob/master/LICENSE" -projectUrl "https://github.com/$($env:APPVEYOR_REPO_NAME)" -packageDescription $env:APPVEYOR_PROJECT_NAME -tags "DesiredStateConfiguration DSC xDscHelper" -destinationPath .


### PR DESCRIPTION
Added support for external resources to configure the maintenance window. This way, the DSC configuration would not need to be changed when a maintenance plan is changed.

The user of the resource is responsible to generate a script block that produces valid hashtable output, containing at least the keys ScheduleStart and ScheduleEnd